### PR TITLE
Allow request-level headers to be set

### DIFF
--- a/aiographql/client/transaction.py
+++ b/aiographql/client/transaction.py
@@ -19,13 +19,14 @@ class GraphQLRequest:
     variables: Dict[str, Any] = field(default=None)
     validate: bool = field(default=True)
     schema: Optional[graphql.GraphQLSchema] = None
+    extra_headers: Dict[str, str] = field(default_factory=dict)
 
     def json(self) -> Dict[str, Any]:
         # TODO: serialise variables correctly
         return {
             k: v
             for k, v in asdict(self).items()
-            if k not in {"schema"} and v is not None
+            if k not in {"schema", "extra_headers"} and v is not None
         }
 
 


### PR DESCRIPTION
To allow client request headers to be sent for a particular request

This will enable using Auth0 with Hasura's auth system