### PR TITLE
Remove dependency on hosted pokemon graphql api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     docker:
       - image: circleci/python:3.7
+      - image: docker.io/devnullcake/graphql-pokemon:latest
     steps:
       - checkout
       - run:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  graphql-pokemon:
+    image: docker.io/devnullcake/graphql-pokemon:latest
+    ports:
+      - 5000:5000

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,7 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        "--pokemon-server",
+        action="store",
+        default="http://localhost:5000",
+        help="GraphQL server to use for integration tests",
+    )

--- a/tests/integration/test_graphql_pokemon.py
+++ b/tests/integration/test_graphql_pokemon.py
@@ -7,9 +7,14 @@ from aiographql.client.transaction import GraphQLRequest
 pytestmark = pytest.mark.asyncio
 
 
+@pytest.fixture
+def server(request):
+    return request.config.getoption("--pokemon-server")
+
+
 @pytest.fixture(autouse=True)
-def client() -> GraphQLClient:
-    return GraphQLClient(endpoint="https://graphql-pokemon.now.sh/")
+def client(server) -> GraphQLClient:
+    return GraphQLClient(endpoint=server)
 
 
 async def test_simple_anonymous_query(client):


### PR DESCRIPTION
The external dependency on the graphql-pokemon api was causing tests
to fail. This change set makes use of the devenullcake/graphql-pokemon
container instead of the hosted version.