### PR TITLE
🧪 test: Add tests for GraphQLClient.get_schema

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any, Dict, cast
 
 from typing import TYPE_CHECKING
 from typing import Any
@@ -12,6 +13,7 @@ import pytest
 from cafeteria.asyncio.callbacks import CallbackRegistry
 from graphql import GraphQLSyntaxError
 
+<<<<<<< HEAD
 from aiographql.client import GraphQLClient
 from aiographql.client import GraphQLClientException
 from aiographql.client import GraphQLClientValidationException
@@ -26,6 +28,18 @@ from aiographql.client.response import GraphQLResponse
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
+=======
+from aiographql.client import (
+    GraphQLClient,
+    GraphQLClientException,
+    GraphQLClientValidationException,
+    GraphQLRequest,
+    GraphQLRequestException,
+    GraphQLSubscription,
+    GraphQLSubscriptionEventType,
+)
+from aiographql.client.helpers import aiohttp_client_session
+>>>>>>> c79b9c1 (test: add type annotations to get_schema tests)
 
 pytestmark = pytest.mark.asyncio
 
@@ -262,6 +276,7 @@ async def test_subscription_on_data_on_error_callbacks(
         assert registry.exists(GraphQLSubscriptionEventType.ERROR, event_on_error)
 
 
+<<<<<<< HEAD
 async def test_subscription_connection_init_payload(
     client: GraphQLClient, subscription_query: str, headers: dict[str, str]
 ) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import asyncio
 
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import cast
 
 import graphql
 import pytest
@@ -303,3 +304,60 @@ async def test_query_method_session_override(mocker: MockerFixture) -> None:
             mock_http_request.assert_called_once()
             args = mock_http_request.call_args[0]
             assert args[0] is custom_session
+
+
+async def test_get_schema_initial_call(
+    mocker: Any, client: GraphQLClient, headers: dict[str, str]
+) -> None:
+    from unittest.mock import AsyncMock
+
+    import graphql
+
+    mock_schema = mocker.MagicMock(spec=graphql.GraphQLSchema)
+    mocker.patch.object(
+        client, "introspect", new_callable=AsyncMock, return_value=mock_schema
+    )
+
+    schema = await client.get_schema(headers=headers)
+
+    cast("AsyncMock", client.introspect).assert_awaited_once_with(headers=headers)
+    assert schema == mock_schema
+    assert client._schema == mock_schema
+
+
+async def test_get_schema_uses_cache(
+    mocker: Any, client: GraphQLClient, headers: dict[str, str]
+) -> None:
+    from unittest.mock import AsyncMock
+
+    import graphql
+
+    mock_schema = mocker.MagicMock(spec=graphql.GraphQLSchema)
+    client._schema = mock_schema
+    mocker.patch.object(client, "introspect", new_callable=AsyncMock)
+
+    schema = await client.get_schema(headers=headers)
+
+    client.introspect.assert_not_called()  # type: ignore[attr-defined]
+    assert schema == mock_schema
+
+
+async def test_get_schema_refresh(
+    mocker: Any, client: GraphQLClient, headers: dict[str, str]
+) -> None:
+    from unittest.mock import AsyncMock
+
+    import graphql
+
+    old_schema = mocker.MagicMock(spec=graphql.GraphQLSchema)
+    new_schema = mocker.MagicMock(spec=graphql.GraphQLSchema)
+    client._schema = old_schema
+    mocker.patch.object(
+        client, "introspect", new_callable=AsyncMock, return_value=new_schema
+    )
+
+    schema = await client.get_schema(refresh=True, headers=headers)
+
+    cast("AsyncMock", client.introspect).assert_awaited_once_with(headers=headers)
+    assert schema == new_schema
+    assert client._schema == new_schema


### PR DESCRIPTION
🎯 **What:** The `GraphQLClient.get_schema` method was previously lacking test coverage. Added tests to verify its caching and refresh behaviors.
📊 **Coverage:** Three new test cases were added:
  - `test_get_schema_initial_call`: Verifies that `introspect` is called on the first invocation and the result is cached.
  - `test_get_schema_uses_cache`: Verifies that subsequent calls return the cached schema without calling `introspect` again.
  - `test_get_schema_refresh`: Verifies that when `refresh=True` is passed, `introspect` is called again and the cache is updated.
✨ **Result:** Test coverage for `GraphQLClient.get_schema` is now implemented, improving code reliability.

---
*PR created automatically by Jules for task [13079014162633171626](https://jules.google.com/task/13079014162633171626) started by @abn*

## Summary by Sourcery

Tests:
- Add async tests ensuring GraphQLClient.get_schema caches the introspected schema, reuses the cache on subsequent calls, and refreshes the schema when requested.