### PR TITLE
🧪 [Testing Improvement] Add test for non-dict dataclass decoding

### DIFF
--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -222,3 +222,13 @@ def test_codec_extra_coverage() -> None:
 
     my_uuid = MyUUID(int=1)
     assert codec.encode(my_uuid) == str(my_uuid)
+
+
+def test_codec_decode_dataclass_failure_non_dict() -> None:
+    codec = DefaultGraphQLCodec()
+    with pytest.raises(
+        GraphQLCodecException,
+        match=f"Cannot decode non-dict value not-a-dict to dataclass {User}",
+    ):
+        codec.decode("not-a-dict", User)
+

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -231,4 +231,3 @@ def test_codec_decode_dataclass_failure_non_dict() -> None:
         match=f"Cannot decode non-dict value not-a-dict to dataclass {User}",
     ):
         codec.decode("not-a-dict", User)
-


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of coverage for the error condition where a non-dictionary value (e.g. a string) is passed to the `decode` function for a Dataclass target type, which correctly raises a `GraphQLCodecException`.
📊 **Coverage:** This adds a specific test in `tests/test_codec.py` named `test_codec_decode_dataclass_failure_non_dict` that expects this failure.
✨ **Result:** Test coverage for `src/aiographql/client/codec.py` has been improved, explicitly catching the non-dict case during dataclass decoding.

---
*PR created automatically by Jules for task [13618117772477183279](https://jules.google.com/task/13618117772477183279) started by @abn*

## Summary by Sourcery

Tests:
- Add a codec test verifying dataclass decoding fails with a clear error when given a non-dict input value.