### PR TITLE
🧪 test(subscription): add test for connection_stop_request

### DIFF
--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -281,3 +281,13 @@ async def test_subscription_routing_aiohttp(mocker: MockerFixture) -> None:
         mock_get_sub.assert_called_once()
         _, kwargs = mock_get_sub.call_args
         assert kwargs["session"] is aiohttp_session
+
+
+def test_subscription_connection_stop_request() -> None:
+    subscription = GraphQLSubscription(request=GraphQLRequest(query="{}"))
+    stop_request = subscription.connection_stop_request()
+    assert stop_request == {
+        "id": subscription.id,
+        "type": GraphQLSubscriptionEventType.STOP.value,
+    }
+

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -290,4 +290,3 @@ def test_subscription_connection_stop_request() -> None:
         "id": subscription.id,
         "type": GraphQLSubscriptionEventType.STOP.value,
     }
-


### PR DESCRIPTION
🎯 **What:** A test for `connection_stop_request` in `GraphQLSubscription` was missing.
📊 **Coverage:** The payload generation for connection stop events is now explicitly tested.
✨ **Result:** Enhanced test coverage for subscription event types, ensuring the `connection_stop_request` logic reliably outputs the correct event format.

---
*PR created automatically by Jules for task [16759319759170881498](https://jules.google.com/task/16759319759170881498) started by @abn*

## Summary by Sourcery

Tests:
- Add a unit test verifying that GraphQLSubscription.connection_stop_request produces the expected STOP event payload.