### PR TITLE
🧪 test: add explicit test for GraphQLRequest __getattr__ fallback

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -52,9 +52,6 @@ def test_graphql_request_asdict() -> None:
     # Test property 'operation' via __getattribute__
     assert request.operation == "GetCity"
 
-    with pytest.raises(AttributeError):
-        _ = request.non_existent
-
     # Test asdict
     expected_dict = {
         "query": "{ city { name } }",
@@ -62,6 +59,13 @@ def test_graphql_request_asdict() -> None:
         "variables": {},
     }
     assert request.asdict() == expected_dict
+
+
+def test_graphql_request_getattr_fallback() -> None:
+    request = GraphQLRequest(query="{ city { name } }", operation="GetCity")
+
+    with pytest.raises(AttributeError):
+        _ = request.non_existent
 
 
 def test_request_payload_extra() -> None:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -61,7 +61,7 @@ def test_graphql_request_asdict() -> None:
     assert request.asdict() == expected_dict
 
 
-def test_graphql_request_getattr_fallback() -> None:
+def test_graphql_request_getattribute_fallback() -> None:
     request = GraphQLRequest(query="{ city { name } }", operation="GetCity")
 
     with pytest.raises(AttributeError):


### PR DESCRIPTION
🎯 **What:** The testing gap for testing invalid attribute access directly on `GraphQLRequest.__getattr__` was addressed. Previously, it was buried in another test.
📊 **Coverage:** The scenario where a user attempts to access an undefined attribute on `GraphQLRequest` is now explicitly tested and isolated.
✨ **Result:** Improved test separation and clarity, ensuring the `__getattr__` implementation relies on `super().__getattribute__` behavior correctly.

---
*PR created automatically by Jules for task [14089311927115356430](https://jules.google.com/task/14089311927115356430) started by @abn*