### PR TITLE
🧹 consolidate module availability checks

### DIFF
--- a/src/aiographql/client/transport/resolver.py
+++ b/src/aiographql/client/transport/resolver.py
@@ -94,7 +94,7 @@ def get_default_transport(
         except ImportError:
             pass
 
-    if _is_module_available("aiohttp"):
+    if _is_aiohttp_available():
         from aiographql.client.transport.aiohttp import AiohttpTransport
 
         return AiohttpTransport(
@@ -103,7 +103,7 @@ def get_default_transport(
             **kwargs,
         )
 
-    if _is_module_available("httpx", min_version="0.24.0"):
+    if _is_httpx_available():
         from aiographql.client.transport.httpx import HttpxTransport
 
         return HttpxTransport(
@@ -142,7 +142,7 @@ def get_default_subscription_transport(
         return transport
 
     # auto or None
-    if _is_module_available("aiohttp"):
+    if _is_aiohttp_available():
         from aiographql.client.transport.aiohttp import AiohttpSubscriptionTransport
 
         return AiohttpSubscriptionTransport(
@@ -151,7 +151,7 @@ def get_default_subscription_transport(
             **kwargs,
         )
 
-    if _is_module_available("websockets"):
+    if _is_websockets_available():
         from aiographql.client.transport.websocket import WebsocketSubscriptionTransport
 
         return WebsocketSubscriptionTransport(endpoint=endpoint, **kwargs)

--- a/src/aiographql/client/transport/resolver.py
+++ b/src/aiographql/client/transport/resolver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import importlib.metadata
 
 from typing import TYPE_CHECKING
@@ -16,17 +17,16 @@ if TYPE_CHECKING:
     from aiographql.client.transport.base import GraphQLTransport
 
 
-def _is_httpx_available(min_version: str = "0.24.0") -> bool:
+def _is_module_available(module_name: str, min_version: str | None = None) -> bool:
     """
-    Check if httpx is available and meets the minimum version requirement.
+    Check if a module is available and optionally meets a minimum version requirement.
     """
     try:
-        import httpx  # noqa: F401
+        importlib.import_module(module_name)
+        if min_version is None:
+            return True
 
-        version = importlib.metadata.version("httpx")
-        # Simple version comparison to avoid adding 'packaging' dependency if not present
-        # but the project likely has it or we can use a simpler check.
-        # Given the environment, let's try to be robust.
+        version = importlib.metadata.version(module_name)
         parts = [int(p) for p in version.split(".") if p.isdigit()]
         min_parts = [int(p) for p in min_version.split(".") if p.isdigit()]
         return parts >= min_parts
@@ -34,28 +34,16 @@ def _is_httpx_available(min_version: str = "0.24.0") -> bool:
         return False
 
 
-def _is_aiohttp_available() -> bool:
-    """
-    Check if aiohttp is available.
-    """
-    try:
-        import aiohttp  # noqa: F401
+def _is_httpx_available(min_version: str = "0.24.0") -> bool:
+    return _is_module_available("httpx", min_version=min_version)
 
-        return True
-    except ImportError:
-        return False
+
+def _is_aiohttp_available() -> bool:
+    return _is_module_available("aiohttp")
 
 
 def _is_websockets_available() -> bool:
-    """
-    Check if websockets is available.
-    """
-    try:
-        import websockets  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
+    return _is_module_available("websockets")
 
 
 def get_default_transport(
@@ -106,7 +94,7 @@ def get_default_transport(
         except ImportError:
             pass
 
-    if _is_aiohttp_available():
+    if _is_module_available("aiohttp"):
         from aiographql.client.transport.aiohttp import AiohttpTransport
 
         return AiohttpTransport(
@@ -115,7 +103,7 @@ def get_default_transport(
             **kwargs,
         )
 
-    if _is_httpx_available():
+    if _is_module_available("httpx", min_version="0.24.0"):
         from aiographql.client.transport.httpx import HttpxTransport
 
         return HttpxTransport(
@@ -154,7 +142,7 @@ def get_default_subscription_transport(
         return transport
 
     # auto or None
-    if _is_aiohttp_available():
+    if _is_module_available("aiohttp"):
         from aiographql.client.transport.aiohttp import AiohttpSubscriptionTransport
 
         return AiohttpSubscriptionTransport(
@@ -163,7 +151,7 @@ def get_default_subscription_transport(
             **kwargs,
         )
 
-    if _is_websockets_available():
+    if _is_module_available("websockets"):
         from aiographql.client.transport.websocket import WebsocketSubscriptionTransport
 
         return WebsocketSubscriptionTransport(endpoint=endpoint, **kwargs)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -27,11 +27,9 @@ def test_resolver_is_module_available_version_check() -> None:
 
 
 def test_resolver_no_transport_available() -> None:
-    with (
-        patch(
-            "aiographql.client.transport.resolver._is_module_available",
-            return_value=False,
-        )
+    with patch(
+        "aiographql.client.transport.resolver._is_module_available",
+        return_value=False,
     ):
         with pytest.raises(RuntimeError, match="No suitable transport found"):
             get_default_transport("http://test")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -6,38 +6,32 @@ from unittest.mock import patch
 
 import pytest
 
-from aiographql.client.transport.resolver import _is_httpx_available
+from aiographql.client.transport.resolver import _is_module_available
 from aiographql.client.transport.resolver import get_default_subscription_transport
 from aiographql.client.transport.resolver import get_default_transport
 
 
-@pytest.mark.httpx
-def test_resolver_is_httpx_available_version_check() -> None:
-    with patch("importlib.metadata.version", return_value="0.23.0"):
-        assert _is_httpx_available(min_version="0.24.0") is False
-    with patch("importlib.metadata.version", return_value="0.24.0"):
-        assert _is_httpx_available(min_version="0.24.0") is True
-    with patch(
-        "importlib.metadata.version",
-        side_effect=importlib.metadata.PackageNotFoundError,
-    ):
-        assert _is_httpx_available() is False
+def test_resolver_is_module_available_version_check() -> None:
+    with patch("aiographql.client.transport.resolver.importlib") as mock_importlib:
+        mock_importlib.metadata.PackageNotFoundError = (
+            importlib.metadata.PackageNotFoundError
+        )
+        mock_importlib.metadata.version.return_value = "0.23.0"
+        assert _is_module_available("httpx", min_version="0.24.0") is False
+
+        mock_importlib.metadata.version.return_value = "0.24.0"
+        assert _is_module_available("httpx", min_version="0.24.0") is True
+
+        mock_importlib.import_module.side_effect = ImportError
+        assert _is_module_available("httpx") is False
 
 
 def test_resolver_no_transport_available() -> None:
     with (
         patch(
-            "aiographql.client.transport.resolver._is_aiohttp_available",
+            "aiographql.client.transport.resolver._is_module_available",
             return_value=False,
-        ),
-        patch(
-            "aiographql.client.transport.resolver._is_httpx_available",
-            return_value=False,
-        ),
-        patch(
-            "aiographql.client.transport.resolver._is_websockets_available",
-            return_value=False,
-        ),
+        )
     ):
         with pytest.raises(RuntimeError, match="No suitable transport found"):
             get_default_transport("http://test")


### PR DESCRIPTION
This PR improves the maintainability of the `aiographql-client` transport resolver by consolidating repetitive module availability and version checks into a single, parameterized helper function.

### Changes
- Added `_is_module_available(module_name: str, min_version: str | None = None)` in `src/aiographql/client/transport/resolver.py`.
- Refactored `get_default_transport` and `get_default_subscription_transport` to use the new helper.
- Maintained `_is_httpx_available`, `_is_aiohttp_available`, and `_is_websockets_available` as thin wrappers around the new helper to avoid breaking existing tests or internal dependencies.
- Updated `tests/test_resolver.py` to directly test `_is_module_available` and simplified its mocking strategy.

### Why
Consolidating these checks reduces boilerplate and makes it easier to add checks for new optional dependencies in the future.

### Verification
- Ran `poetry run pytest tests/test_resolver.py`, which passes.
- Confirmed the logic remains identical for version comparison.
- Verified that mocking `importlib` in the resolver namespace works as expected for the new implementation.

---
*PR created automatically by Jules for task [5066154940520923638](https://jules.google.com/task/5066154940520923638) started by @abn*